### PR TITLE
fix: correctly handle the case where the library user has already added a root query, mutation, or subscription type.

### DIFF
--- a/example/LiveDocs.GraphQLApi/Models/Query.cs
+++ b/example/LiveDocs.GraphQLApi/Models/Query.cs
@@ -1,0 +1,3 @@
+﻿namespace LiveDocs.GraphQLApi.Models;
+
+public sealed class Query;

--- a/example/LiveDocs.GraphQLApi/Startup.cs
+++ b/example/LiveDocs.GraphQLApi/Startup.cs
@@ -40,6 +40,9 @@ public class Startup
             {
                 o.IncludeExceptionDetails = environment.IsDevelopment();
             })
+            // Simulate scenario where the library user
+            // has already added their own root query type.
+            .AddQueryType<Models.Query>()
             .AddReplicationServer()
             .AddReplicatedDocument<Hero>()
             .AddReplicatedDocument<User>()

--- a/src/RxDBDotNet/Documents/IReplicatedDocument.cs
+++ b/src/RxDBDotNet/Documents/IReplicatedDocument.cs
@@ -6,9 +6,10 @@
 public interface IReplicatedDocument
 {
     /// <summary>
-    ///     The unique identifier for the document.
+    /// Gets the client-assigned identifier for this document.
+    /// This property is used for client-side identification and replication purposes.
     /// </summary>
-    Guid Id { get; init; }
+    Guid Id { get; }
 
     /// <summary>
     ///     The timestamp of the last update to the document.


### PR DESCRIPTION
#### PR Classification
Code cleanup and feature enhancement.

#### PR Summary
Refactored and enhanced GraphQL server configuration and document handling.
- `Query.cs`: Updated `Query` class to be sealed and moved to `LiveDocs.GraphQLApi.Models` namespace.
- `Startup.cs`: Added new root query type `Models.Query` to GraphQL server configuration.
- `IReplicatedDocument.cs`: Changed `Id` property in `IReplicatedDocument` interface to read-only.
- `GraphQLBuilderExtensions.cs`: Added methods for configuring document mutations and subscriptions, improved code readability, and refactored root type checks.
