### PR TITLE
fix: issue with using constructor injection for resolver classes

### DIFF
--- a/example/LiveDocs.GraphQLApi/Startup.cs
+++ b/example/LiveDocs.GraphQLApi/Startup.cs
@@ -44,6 +44,7 @@ public class Startup
             // has already added their own root query type.
             .AddQueryType<Models.Query>()
             .AddReplicationServer()
+            .RegisterService<IDocumentRepository<Workspace>>()
             .AddReplicatedDocument<Hero>()
             .AddReplicatedDocument<User>()
             .AddReplicatedDocument<Workspace>()

--- a/src/RxDBDotNet/Resolvers/QueryResolver.cs
+++ b/src/RxDBDotNet/Resolvers/QueryResolver.cs
@@ -8,7 +8,13 @@ namespace RxDBDotNet.Resolvers;
 /// <summary>
 /// Represents a GraphQL query resolver for pulling documents.
 /// This class implements the server-side logic for the 'pull' operation in the RxDB replication protocol.
+/// Note that this class must not use constructor injection per:
+/// https://chillicream.com/docs/hotchocolate/v13/server/dependency-injection#constructor-injection
 /// </summary>
+/// <remarks>
+/// Note that this class must not use constructor injection per:
+/// https://chillicream.com/docs/hotchocolate/v13/server/dependency-injection#constructor-injection
+/// </remarks>
 /// <typeparam name="TDocument">The type of the document to be pulled, which must implement IReplicatedDocument.</typeparam>
 public sealed class QueryResolver<TDocument> where TDocument : class, IReplicatedDocument
 {
@@ -35,7 +41,7 @@ public sealed class QueryResolver<TDocument> where TDocument : class, IReplicate
     internal async Task<DocumentPullBulk<TDocument>> PullDocumentsAsync(
         Checkpoint? checkpoint,
         int limit,
-        IDocumentRepository<TDocument> repository,
+        [Service] IDocumentRepository<TDocument> repository,
         IResolverContext context,
         CancellationToken cancellationToken)
     {


### PR DESCRIPTION
#### PR Classification
Code cleanup and enhancement of dependency injection.

#### PR Summary
Refactors dependency injection in GraphQL resolvers to use method parameter injection and adds new tests.
- `MutationResolver`, `QueryResolver`, and `SubscriptionResolver` updated to use `[Service]` attribute for dependency injection.
- `Startup.cs` registers `IDocumentRepository<Workspace>` service.
- `GraphQLBuilderExtensions.cs` injects `ITopicEventReceiver` and `ILogger` into `SubscriptionResolver`.
- New test method `ItShouldHandleMultiplePullsFollowedByAPush` added in `BasicDocumentOperationsTests.cs`.
