### PR TITLE
fix: align the subscription connection init message payload with RxDB's format

### DIFF
--- a/src/RxDBDotNet/Security/Headers.cs
+++ b/src/RxDBDotNet/Security/Headers.cs
@@ -1,0 +1,12 @@
+﻿namespace RxDBDotNet.Security;
+
+public sealed class Headers
+{
+    /// <summary>
+    /// Gets the authorization token required for establishing a WebSocket connection.
+    /// </summary>
+    /// <value>
+    /// A string representing the authorization token, typically in the form of a JWT.
+    /// </value>
+    public required string Authorization { get; init; }
+}

--- a/src/RxDBDotNet/Security/SocketConnectPayload.cs
+++ b/src/RxDBDotNet/Security/SocketConnectPayload.cs
@@ -6,10 +6,10 @@
 public class SocketConnectPayload
 {
     /// <summary>
-    /// Gets the authorization token required for establishing a WebSocket connection.
+    /// Gets the headers required for the socket connection, including authorization information.
     /// </summary>
     /// <value>
-    /// A string representing the authorization token, typically in the form of a JWT.
+    /// An instance of the <see cref="Headers"/> class containing the necessary authorization details.
     /// </value>
-    public required string Authorization { get; init; }
+    public required Headers Headers { get; init; }
 }

--- a/src/RxDBDotNet/Security/SubscriptionAuthMiddleware.cs
+++ b/src/RxDBDotNet/Security/SubscriptionAuthMiddleware.cs
@@ -92,7 +92,7 @@ public class SubscriptionAuthMiddleware : DefaultSocketSessionInterceptor
 
             // JWT Bearer is configured, so we proceed with token validation
             var connectPayload = connectionInitMessage.As<SocketConnectPayload>();
-            var authorizationHeader = connectPayload?.Authorization;
+            var authorizationHeader = connectPayload?.Headers.Authorization;
 
             // Ensure the Authorization header is present and in the correct format
             if (string.IsNullOrEmpty(authorizationHeader) || !authorizationHeader.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))

--- a/tests/RxDBDotNet.Tests/Utils/GraphQLSubscriptionClient.cs
+++ b/tests/RxDBDotNet.Tests/Utils/GraphQLSubscriptionClient.cs
@@ -1,6 +1,7 @@
 ﻿using System.Net.WebSockets;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using RxDBDotNet.Security;
 
 namespace RxDBDotNet.Tests.Utils;
 
@@ -101,9 +102,12 @@ public sealed class GraphQLSubscriptionClient : IAsyncDisposable
             initMessage = new
             {
                 type = "connection_init",
-                payload = new
+                payload = new SocketConnectPayload
                 {
-                    Authorization = $"Bearer {_bearerToken}",
+                    Headers = new Headers
+                    {
+                        Authorization = $"Bearer {_bearerToken}",
+                    },
                 },
             };
         }


### PR DESCRIPTION
#### PR Classification
API change to encapsulate authorization details within a new `Headers` class.

#### PR Summary
Refactored authorization handling by introducing a `Headers` class and updating related classes to use it.
- Introduced `Headers` class in `RxDBDotNet.Security` namespace with an `Authorization` property.
- Modified `SocketConnectPayload` to use `Headers` instead of a direct `Authorization` property.
- Updated `SubscriptionAuthMiddleware` to access the authorization token via `Headers`.
- Updated `GraphQLSubscriptionClient` to use the new `SocketConnectPayload` structure.
- Added `using RxDBDotNet.Security` directive in `GraphQLSubscriptionClient.cs`.
