### PR TITLE
feat: add support for OIDC-configured JWT authentication in GraphQL subscriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -612,6 +612,36 @@ builder.Services
 
 With this configuration, when these exceptions are thrown in your `UserService` during replication operations, RxDBDotNet will handle them appropriately and include them in the GraphQL response.
 
+### OpenID Connect (OIDC) Support for Subscription Authentication
+
+RxDBDotNet now supports OpenID Connect (OIDC) configuration for JWT validation in GraphQL subscriptions. This enhancement allows for more flexible and secure authentication setups, especially when working with OIDC-compliant identity providers.
+
+#### Key Features:
+
+- Dynamic retrieval of OIDC configuration, including signing keys
+- Support for key rotation without requiring application restarts
+- Seamless integration with existing JWT authentication setups
+
+#### Usage:
+
+1. Ensure your application is configured to use JWT Bearer authentication with OIDC support:
+
+```csharp
+builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+    .AddJwtBearer(options =>
+    {
+        options.Authority = "https://your-oidc-provider.com";
+        options.Audience = "your-api-audience";
+        // Other JWT options...
+    });
+```
+
+2. The WebSocketJwtAuthInterceptor will automatically use the OIDC configuration when validating tokens for GraphQL subscriptions.
+
+3. No additional configuration is needed in your GraphQL setup. The OIDC support is automatically applied to subscription authentication when available.
+
+This feature allows for more robust and flexible authentication scenarios, particularly in environments where signing keys may change dynamically or where you're integrating with external OIDC providers like IdentityServer.
+
 ## Contributing
 
 We welcome contributions to RxDBDotNet! Here's how you can contribute:

--- a/README.md
+++ b/README.md
@@ -646,6 +646,3 @@ Please see our [Security Policy](./SECURITY.md) for information on reporting sec
 - Thanks to the RxDB project for inspiring this .NET implementation.
 - Thanks to the Hot Chocolate team for their excellent GraphQL server implementation.
 
-## Contact
-
-If you have any questions, concerns, or support requests, please open an issue on our [GitHub repository](https://github.com/Ziptility/RxDBDotNet/issues).

--- a/src/RxDBDotNet/Extensions/GraphQLBuilderExtensions.cs
+++ b/src/RxDBDotNet/Extensions/GraphQLBuilderExtensions.cs
@@ -37,7 +37,7 @@ public static class GraphQLBuilderExtensions
 
         builder.AddFiltering();
 
-        builder.AddSocketSessionInterceptor<SubscriptionAuthMiddleware>();
+        builder.AddSocketSessionInterceptor<WebSocketJwtAuthInterceptor>();
 
         // Ensure Query, Mutation, and Subscription types exist
         EnsureRootTypesExist(builder);

--- a/tests/RxDBDotNet.Tests/SubscriptionTests.cs
+++ b/tests/RxDBDotNet.Tests/SubscriptionTests.cs
@@ -1,7 +1,14 @@
 ﻿using System.Diagnostics;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Security.Cryptography;
 using HotChocolate.Execution;
 using HotChocolate.Subscriptions;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using Microsoft.IdentityModel.Protocols;
+using Microsoft.IdentityModel.Tokens;
 using Moq;
 using RxDBDotNet.Models;
 using RxDBDotNet.Tests.Model;
@@ -22,6 +29,127 @@ public class SubscriptionTests : IAsyncLifetime
     public async Task DisposeAsync()
     {
         await TestContext.DisposeAsync();
+    }
+
+    /// <summary>
+    /// Tests the WebSocketJwtAuthInterceptor's ability to handle JWT authentication with OpenID Connect (OIDC) configuration.
+    /// </summary>
+    /// <remarks>
+    /// This test verifies that:
+    /// 1. The interceptor can successfully retrieve and use OIDC configuration for token validation.
+    /// 2. A valid JWT token allows the establishment of a GraphQL subscription.
+    /// 3. The subscription can receive events after successful authentication.
+    /// <para>
+    /// The test is structured as follows:
+    /// - Arrange:
+    ///   a) Create a test RSA key and JWT token.
+    ///   b) Mock the OIDC configuration manager to return a known configuration.
+    ///   c) Configure the test scenario with custom JWT options.
+    ///   d) Set up a GraphQL subscription client with the test token.
+    /// - Act:
+    ///   a) Attempt to establish a subscription.
+    ///   b) Create a workspace to trigger a subscription event.
+    /// - Assert:
+    ///   Verify that the subscription receives the workspace creation event without errors.
+    /// </para>
+    /// This structure allows us to test the entire flow from token validation to subscription handling,
+    /// ensuring that the OIDC configuration retrieval and JWT validation work correctly in the context
+    /// of GraphQL subscriptions over WebSockets.
+    /// </remarks>
+    [Fact]
+    public async Task ReplicationApiShouldSupportOidcConfiguredJwtAuthentication()
+    {
+        // Arrange
+
+        // Create a test RSA key and signing credentials
+        // This simulates the cryptographic material that would be used by an actual OIDC provider
+        using var rsa = RSA.Create(2048);
+        var signingKey = new RsaSecurityKey(rsa);
+        var signingCredentials = new SigningCredentials(signingKey, SecurityAlgorithms.RsaSha256);
+
+        // Create a test JWT token signed with our test key
+        var token = CreateTestToken(signingCredentials);
+
+        // Mock the OIDC configuration manager
+        // This simulates the retrieval of OIDC configuration from a discovery endpoint
+        var mockConfigManager = new Mock<IConfigurationManager<OpenIdConnectConfiguration>>();
+        mockConfigManager.Setup(m => m.GetConfigurationAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new OpenIdConnectConfiguration
+            {
+                SigningKeys = { signingKey },
+            });
+
+        // Set up the test context with custom JWT options
+        // This configuration ensures that our test uses the mocked OIDC configuration
+        // and validates tokens using our test signing key
+        TestContext = new TestScenarioBuilder()
+            .WithAuthorization()
+            .ConfigureServices(services =>
+            {
+                services.PostConfigure<JwtBearerOptions>(JwtBearerDefaults.AuthenticationScheme, options =>
+                {
+                    options.Configuration = null; // Ensure we're not using any pre-configured values
+                    options.ConfigurationManager = mockConfigManager.Object;
+                    options.TokenValidationParameters = new TokenValidationParameters
+                    {
+                        ValidateIssuerSigningKey = true,
+#pragma warning disable CA5404 // we are not testing this aspect
+                        ValidateAudience = false,
+                        ValidateIssuer = false,
+                    };
+                });
+            })
+            .Build();
+
+        // Create a GraphQL subscription client with our test token
+        await using var subscriptionClient = await TestContext.Factory.CreateGraphQLSubscriptionClientAsync(
+            TestContext.CancellationToken,
+            bearerToken: token);
+
+        // Prepare a subscription query
+        var subscriptionQuery = new SubscriptionQueryBuilderGql()
+            .WithStreamWorkspace(new WorkspacePullBulkQueryBuilderGql().WithAllFields())
+            .Build();
+
+        // Act
+
+        // Attempt to establish a subscription and collect responses
+        var subscriptionTask = CollectSubscriptionDataAsync(subscriptionClient, subscriptionQuery, TestContext.CancellationToken, maxResponses: 1);
+
+        // Ensure the subscription has time to be established
+        await Task.Delay(1000, TestContext.CancellationToken);
+
+        // Create a workspace to trigger a subscription event
+        // This tests that the authenticated subscription is working end-to-end
+        await TestContext.HttpClient.CreateWorkspaceAsync(TestContext.CancellationToken);
+
+        // Assert
+
+        // Verify that we received exactly one subscription response (the workspace creation event)
+        var subscriptionResponses = await subscriptionTask;
+        subscriptionResponses.Should().HaveCount(1, "The subscription should have received the workspace creation event");
+
+        // Verify that the subscription response contains no errors
+        subscriptionResponses[0].Errors.Should().BeNullOrEmpty("There should be no errors in the subscription response");
+    }
+
+    private static string CreateTestToken(SigningCredentials signingCredentials)
+    {
+        var claims = new[]
+        {
+            new Claim(ClaimTypes.Name, "Test User"),
+            new Claim(ClaimTypes.NameIdentifier, Guid.NewGuid().ToString()),
+        };
+
+        var token = new JwtSecurityToken(
+            issuer: "test-issuer",
+            audience: "test-audience",
+            claims: claims,
+            expires: DateTime.UtcNow.AddHours(1),
+            signingCredentials: signingCredentials
+        );
+
+        return new JwtSecurityTokenHandler().WriteToken(token);
     }
 
     [Fact]


### PR DESCRIPTION
#### PR Classification
New feature: Added OpenID Connect (OIDC) support for subscription authentication.

#### PR Summary
Introduced OIDC support for JWT Bearer authentication in .NET applications, enhancing security and integration.
- **README.md**: Added section on OIDC support and usage instructions.
- **GraphQLBuilderExtensions.cs**: Replaced `SubscriptionAuthMiddleware` with `WebSocketJwtAuthInterceptor`.
- **WebSocketJwtAuthInterceptor.cs**: Implemented JWT token extraction, validation, and dynamic OIDC configuration updates.
- **SubscriptionTests.cs**: Added tests for OIDC-configured JWT authentication, including helper methods for token generation.
