### PR TITLE
build: try a specific version of the runner since ubuntu-latest is causing tests to fail

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build-test-main:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build-test-main:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
       with:


### PR DESCRIPTION
The tests previously succeeded on the main branch, but suddenly, they started failing even though no code changes had been made.